### PR TITLE
Add Lipinski analyzer module

### DIFF
--- a/modules/lipinski_analyzer/lipinski_analyzer.md
+++ b/modules/lipinski_analyzer/lipinski_analyzer.md
@@ -1,0 +1,15 @@
+# Lipinski Analyzer Module
+
+## Overview
+
+This module retrieves a compound from PubChem using its CID and
+calculates basic Lipinski descriptors with **RDKit**. Parameters are
+printed to the console and saved to a log file.
+
+## Usage
+
+1. Edit `lipinski_analyzer.yaml` to set the PubChem `drug_id` or provide
+   a `smiles` string.
+2. Run `python lipinski_analyzer.py`.
+
+A log file `lipinski_analyzer.log` will be created in the same folder.

--- a/modules/lipinski_analyzer/lipinski_analyzer.py
+++ b/modules/lipinski_analyzer/lipinski_analyzer.py
@@ -1,0 +1,60 @@
+import os
+import logging
+import traceback
+from colorama import Fore, Style
+import requests
+from rdkit import Chem
+from rdkit.Chem import Descriptors
+import yaml
+
+
+def fetch_smiles(drug_id: str) -> str:
+    """Fetch SMILES string for a PubChem CID."""
+    url = (
+        f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/{drug_id}/"
+        "property/CanonicalSMILES/JSON"
+    )
+    r = requests.get(url, timeout=10)
+    r.raise_for_status()
+    return r.json()["PropertyTable"]["Properties"][0]["CanonicalSMILES"]
+
+
+def calculate_lipinski(smiles: str) -> dict:
+    """Compute basic Lipinski descriptors from a SMILES string."""
+    mol = Chem.MolFromSmiles(smiles)
+    return {
+        "MolecularWeight": Descriptors.MolWt(mol),
+        "LogP": Descriptors.MolLogP(mol),
+        "NumHDonors": Descriptors.NumHDonors(mol),
+        "NumHAcceptors": Descriptors.NumHAcceptors(mol),
+    }
+
+
+def main() -> None:
+    module_name = os.path.splitext(os.path.basename(__file__))[0]
+    config_path = os.path.join(os.path.dirname(__file__), f"{module_name}.yaml")
+    with open(config_path, "r") as fh:
+        config = yaml.safe_load(fh)
+
+    logging.basicConfig(
+        filename=os.path.join(os.path.dirname(__file__), "lipinski_analyzer.log"),
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+
+    try:
+        smiles = config.get("smiles")
+        if not smiles:
+            smiles = fetch_smiles(config["drug_id"])
+        params = calculate_lipinski(smiles)
+        for k, v in params.items():
+            print(f"{Fore.BLUE}{k}: {v}{Style.RESET_ALL}")
+        logging.info("Parameters: %s", params)
+    except Exception as exc:
+        logging.error("Error: %s", exc)
+        print(Fore.RED + "An error occurred" + Style.RESET_ALL)
+        print(Fore.YELLOW + traceback.format_exc() + Style.RESET_ALL)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/lipinski_analyzer/lipinski_analyzer.yaml
+++ b/modules/lipinski_analyzer/lipinski_analyzer.yaml
@@ -1,0 +1,1 @@
+drug_id: "387447"  # PubChem CID for aspirin

--- a/modules/lipinski_analyzer/requirements.txt
+++ b/modules/lipinski_analyzer/requirements.txt
@@ -1,0 +1,4 @@
+rdkit
+requests
+PyYAML
+colorama


### PR DESCRIPTION
## Summary
- create a new `lipinski_analyzer` module
- implement descriptor calculations from PubChem/SMILES
- document usage and add example YAML config

## Testing
- `python -m py_compile modules/lipinski_analyzer/lipinski_analyzer.py`

------
https://chatgpt.com/codex/tasks/task_e_68679034a0a08330b93004887dbf2969